### PR TITLE
Fix module name to match import path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ go.work
 # Local stuff
 .vscode/launch.json
 build/*
+lotw-trust

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module lotw-trust/main
+module github.com/Mihara/lotw-trust
 
 go 1.20
 


### PR DESCRIPTION
Hi there - really neat tool. I noticed when I tried to go install the package (I'm using an arm64 laptop) that I got the following error:

```
go: downloading github.com/Mihara/lotw-trust v0.0.1
go: github.com/Mihara/lotw-trust@latest: github.com/Mihara/lotw-trust@v0.0.1: parsing go.mod:
	module declares its path as: lotw-trust/main
	        but was required as: github.com/Mihara/lotw-trust
```

This pr fixes the module name in the go.mod file so that it matches.